### PR TITLE
Add shutdown/reboot commands to cncjs menu

### DIFF
--- a/src/modules/cncjs/filesystem/home/pi/.cncrc
+++ b/src/modules/cncjs/filesystem/home/pi/.cncrc
@@ -5,5 +5,17 @@
                 "autoReconnect": false
             }
         }
-    }
+    },
+    "commands": [
+        {
+            "title": "Reboot",
+            "commands": "sudo reboot",
+            "enabled": true
+        },
+        {
+            "title": "Shutdown",
+            "commands": "sudo poweroff",
+            "enabled": true
+        }
+    ]
 }


### PR DESCRIPTION
Requires passwordless sudo privileges for pi user, should be default

https://github.com/jeffeb3/v1pi/issues/6