### PR TITLE
Update Raspios, Octopi, CNCJS to latest

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: Build Image
 
 on:
   schedule:
-    # At 10:15 each day. No idea what time zone this is...
+    # At 10:15 each day. No idea what time zone this is... UTC
     - cron:  '15 10 * * *'
 
   pull_request: {}
@@ -66,12 +66,13 @@ jobs:
       run: sudo modprobe loop && cd repository/src && sudo bash -x ./build_dist
 
     - name: Copy Output
-      run: cp ${{ github.workspace }}/repository/src/workspace/*-raspios-buster-armhf-lite.img "v1pi-${{ env.V1PI_VERSION }}-${{ matrix.hotspot }}".img
+      run: cp ${{ github.workspace }}/repository/src/workspace/*-raspios-bullseye-armhf-lite.img "v1pi-${{ env.V1PI_VERSION }}-${{ matrix.hotspot }}".img
 
     - name: Zip Output
       run: zip -prq "v1pi-${{ env.V1PI_VERSION }}-${{ matrix.hotspot }}".zip "v1pi-${{ env.V1PI_VERSION }}-${{ matrix.hotspot }}".img
 
-    - uses: actions/upload-artifact@v1
+    - name: Upload Artifacts
+      uses: actions/upload-artifact@v2
       with:
         name: v1pi-${{ env.V1PI_VERSION }}-${{ matrix.hotspot }}
         path: v1pi-${{ env.V1PI_VERSION }}-${{ matrix.hotspot }}.img

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,8 @@ on:
 
   pull_request: {}
   push:
+    branches:
+      - master
     tags:
       - v*
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,7 @@ jobs:
         submodules: true
 
     - name: Download Raspbian Image
-      run: cd repository/src/image && wget -q -c --trust-server-names 'https://downloads.raspberrypi.org/raspbian_lite_latest'
+      run: cd repository/src/image && wget -q -c --trust-server-names 'https://downloads.raspberrypi.org/raspios_lite_armhf_latest'
 
     - name: Update CustomPiOS Paths
       run: cd repository/src && ../../CustomPiOS/src/update-custompios-paths
@@ -64,7 +64,7 @@ jobs:
       run: sudo modprobe loop && cd repository/src && sudo bash -x ./build_dist
 
     - name: Copy Output
-      run: cp ${{ github.workspace }}/repository/src/workspace/*-raspbian-buster-lite.img "v1pi-${{ env.V1PI_VERSION }}-${{ matrix.hotspot }}".img
+      run: cp ${{ github.workspace }}/repository/src/workspace/*-raspios-buster-armhf-lite.img "v1pi-${{ env.V1PI_VERSION }}-${{ matrix.hotspot }}".img
 
     - name: Zip Output
       run: zip -prq "v1pi-${{ env.V1PI_VERSION }}-${{ matrix.hotspot }}".zip "v1pi-${{ env.V1PI_VERSION }}-${{ matrix.hotspot }}".img

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,7 +19,7 @@ theme:
   favicon: "img/favicon.ico"
 
 extra:
-  version: 0.17.0
+  version: 0.18.0
   social:
     - type: 'github'
       link: 'https://github.com/jeffeb3'

--- a/src/config
+++ b/src/config
@@ -1,6 +1,6 @@
 export DIST_NAME=v1pi
 export DIST_VERSION=0.18.0
-export BASE_IMAGE_ENLARGEROOT=800
+export BASE_IMAGE_ENLARGEROOT=1200
 
 source ./hotspot.sh
 

--- a/src/config
+++ b/src/config
@@ -1,5 +1,5 @@
 export DIST_NAME=v1pi
-export DIST_VERSION=0.17.1
+export DIST_VERSION=0.18.0
 export BASE_IMAGE_ENLARGEROOT=800
 
 source ./hotspot.sh

--- a/src/config
+++ b/src/config
@@ -1,6 +1,6 @@
 export DIST_NAME=v1pi
 export DIST_VERSION=0.18.0
-export BASE_IMAGE_ENLARGEROOT=1200
+export BASE_IMAGE_ENLARGEROOT=1400
 
 source ./hotspot.sh
 

--- a/src/modules/cncjs/filesystem/home/pi/.cncrc
+++ b/src/modules/cncjs/filesystem/home/pi/.cncrc
@@ -5,5 +5,15 @@
                 "autoReconnect": false
             }
         }
+    },
+    "commands": [
+    {
+      "title": "Reboot",
+      "commands": "sudo shutdown -r now"
+    },
+    {
+      "title": "Shutdown",
+      "commands": "sudo shutdown -h now"
     }
+  ]
 }

--- a/src/modules/cncjs/filesystem/home/pi/landingPage/serve.py
+++ b/src/modules/cncjs/filesystem/home/pi/landingPage/serve.py
@@ -10,13 +10,13 @@ def getServiceRunning(service):
         output = subprocess.check_output(['service', service, 'status'])
     except subprocess.CalledProcessError as err:
         output = err.output
-    if 'active (running)' in output:
+    if b'active (running)' in output:
         print("{} is running".format(service))
         return True
-    if 'active (exited)' in output:
+    if b'active (exited)' in output:
         print("{} has exited".format(service))
         return False
-    if 'inactive (dead)' in output:
+    if b'inactive (dead)' in output:
         print("{} is dead".format(service))
         return False
     print("{} is unknown".format(service))

--- a/src/modules/cncjs/filesystem/root/etc/haproxy/haproxy.cfg
+++ b/src/modules/cncjs/filesystem/root/etc/haproxy/haproxy.cfg
@@ -15,8 +15,8 @@ defaults
         option forwardfor
         maxconn 2000
         timeout connect 5s
-        timeout client  15min
-        timeout server  15min
+        timeout client  15m
+        timeout server  15m
 
 frontend landing
         bind :::80 v4v6
@@ -45,7 +45,7 @@ backend octoprint
         errorfile 503 /etc/haproxy/errors/503-no-octoprint.http
 
 backend webcam
-        reqrep ^([^\ :]*)\ /webcam[/]?(.*)     \1\ /\2
+        http-request replace-uri ^([^\ :]*)\ /webcam[/]?(.*)     \1\ /\2
         server webcam1  127.0.0.1:8080
         errorfile 503 /etc/haproxy/errors/503-no-webcam.http
 

--- a/src/modules/cncjs/start_chroot_script
+++ b/src/modules/cncjs/start_chroot_script
@@ -38,7 +38,7 @@ pushd /home/pi
       # make links to the logos
       pushd landingPage/static
         ln -s /usr/local/lib/node_modules/cncjs/dist/cncjs/app/images/logo-badge-256x256.png logo_cncjs.png
-        ln -s /home/pi/oprint/lib/python3.7/site-packages/octoprint/static/img/logo.png logo_octoprint.png
+        ln -s /home/pi/oprint/lib/python3.9/site-packages/octoprint/static/img/logo.png logo_octoprint.png
         ln -s /var/www/html/app/img/raspAP-logo.png logo_raspap.png
       popd
 

--- a/src/modules/cncjs/start_chroot_script
+++ b/src/modules/cncjs/start_chroot_script
@@ -44,7 +44,8 @@ pushd /home/pi
 
       #build virtualenv
       pushd landingPage
-        sudo -u pi virtualenv flask
+	    # Change to python2 if the landingPage is not comaptible
+        sudo -u pi python3 -m virtualenv --python=python3 virtualenv flask
         sudo -u pi ./flask/bin/pip install --upgrade pip
         PIP_DEFAULT_TIMEOUT=60 sudo -u pi ./flask/bin/pip install flask
       popd

--- a/src/modules/cncjs/start_chroot_script
+++ b/src/modules/cncjs/start_chroot_script
@@ -38,7 +38,7 @@ pushd /home/pi
       # make links to the logos
       pushd landingPage/static
         ln -s /usr/local/lib/node_modules/cncjs/dist/cncjs/app/images/logo-badge-256x256.png logo_cncjs.png
-        ln -s /home/pi/oprint/lib/python2.7/site-packages/octoprint/static/img/logo.png logo_octoprint.png
+        ln -s /home/pi/oprint/lib/python3.7/site-packages/octoprint/static/img/logo.png logo_octoprint.png
         ln -s /var/www/html/app/img/raspAP-logo.png logo_raspap.png
       popd
 

--- a/src/modules/cncjs/start_chroot_script
+++ b/src/modules/cncjs/start_chroot_script
@@ -45,7 +45,7 @@ pushd /home/pi
       #build virtualenv
       pushd landingPage
 	    # Change to python2 if the landingPage is not comaptible
-        sudo -u pi python3 -m virtualenv --python=python3 virtualenv flask
+        sudo -u pi python3 -m virtualenv --python=python3 flask
         sudo -u pi ./flask/bin/pip install --upgrade pip
         PIP_DEFAULT_TIMEOUT=60 sudo -u pi ./flask/bin/pip install flask
       popd

--- a/src/modules/nodejs/config
+++ b/src/modules/nodejs/config
@@ -2,8 +2,9 @@
 # All our config settings must start with NODEJS
 
 # node.js archive
-# The version of node.js needed for cnc.js is 6: https://cnc.js.org/
-[ -n "$NODEJS_VERSION_STRING" ]  || NODEJS_VERSION_STRING="v6.17.1"
+# The version of node.js needed for cnc.js is 10 or 12: https://cnc.js.org/
+# v10.24.1 armv6l (Pi1,Zero), v12.22.7 arm7l (PI3,4,Zero2 ARMV8)
+[ -n "$NODEJS_VERSION_STRING" ]  || NODEJS_VERSION_STRING="v10.24.1"
 [ -n "$NODEJS_ARCH_STRING" ]     || NODEJS_ARCH_STRING="linux-armv6l"
 [ -n "$NODEJS_VERSION_FOLDER" ]  || NODEJS_VERSION_FOLDER="node-$NODEJS_VERSION_STRING-$NODEJS_ARCH_STRING"
 [ -n "$NODEJS_VERSION_TAR" ]     || NODEJS_VERSION_TAR="$NODEJS_VERSION_FOLDER.tar.gz"


### PR DESCRIPTION
Update base to Raspios bullseye.
Update Octopi to V0.18 - octoprint 1.7.2
Update CNCJS to to 1.19.23
Update Nodejs to v10.24.1

This also includes the changes from jelkose/v1pi.

There was a change to HAProxy that affected the config file. _Reqrep_ was dropped and replaced with _http-request replace-uri_. I am not really sure if the expression needs to be updated too. I currently do not have a webcam to test this with.
 -       reqrep ^([^\ :]*)\ /webcam[/]?(.*)     \1\ /\2
 +       http-request replace-uri ^([^\ :]*)\ /webcam[/]?(.*)     \1\ /\2

I had to expand the _export BASE_IMAGE_ENLARGEROOT=1200_ as I could not get it to build when it was smaller. 

Nodejs could be updated to V12 which is the latest supported by CNCJS but Nodejs dropped support for armv6 after V10. This would affect Pi1 and Zero. The Zero 2 is armv8 along with Pi3 and Pi4. I think there was some Pi2 that were either armv7 or armv8. As far as I can tell octopi suggests only using Pi3, Pi4, and Zero 2, so it might be a matter of deciding if support for the oldest Pi's is dropped.

I have tested running the no-hotspot on a Pi4 and it boots and both Octoprint and CNCJS appear to run. I also have a Zero 2 to try it on. I do not currently have a running CNC to try out, hopefully, that will be fixed soon.

Hamish